### PR TITLE
Fix empty api class

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,6 +6,7 @@ tasks:
   install:
     cmds:
       - go install github.com/apigear-io/cli/cmd/apigear@latest
+      - pip install black
       # - rm -rf tmp bin
       # - mkdir tmp bin
       # - gh release download --repo apigear-io/cli --pattern "apigear_{{OS}}_{{ARCH}}.zip" --dir tmp
@@ -36,6 +37,10 @@ tasks:
   diff:
     cmds:
       - git --no-pager diff --no-index ./goldenmaster ./test
+  format:
+    dir: test
+    cmds:
+      - black .
   ci:
     desc: runs the ci pipeline
     cmds:

--- a/apigear/goldenmaster.solution.yaml
+++ b/apigear/goldenmaster.solution.yaml
@@ -11,6 +11,7 @@ layers:
       - testbed.same2.module.yaml
       - testbed.simple.module.yaml
       - testbed.struct.module.yaml
+      - testbed.empty.module.yaml
     output: ../test
     template: ..
     force: true

--- a/apigear/testbed.empty.module.yaml
+++ b/apigear/testbed.empty.module.yaml
@@ -1,0 +1,12 @@
+schema: apigear.module/1.0
+name: tb.empty
+version: "1.0"
+
+interfaces:
+  - name: EmptyInterface
+
+structs:
+  - name: EmptyStruct
+
+enums:
+  - name: EmptyEnum

--- a/goldenmaster/http/server.py
+++ b/goldenmaster/http/server.py
@@ -6,7 +6,8 @@ import tb.enum.http.routes
 import tb.same1.http.routes  
 import tb.same2.http.routes  
 import tb.simple.http.routes  
-import testbed1.http.routes
+import testbed1.http.routes  
+import tb.empty.http.routes
 
 app = FastAPI()
 
@@ -39,4 +40,9 @@ app.include_router(
 app.include_router(
     router=testbed1.http.routes.router,
     prefix="/testbed1",
+)
+
+app.include_router(
+    router=tb.empty.http.routes.router,
+    prefix="/tb.empty",
 )

--- a/goldenmaster/olink_client.py
+++ b/goldenmaster/olink_client.py
@@ -11,6 +11,7 @@ import tb_same1_olink
 import tb_same2_olink
 import tb_simple_olink
 import testbed1_olink
+import tb_empty_olink
 
 class Client:
     def __init__(self, node: ClientNode):
@@ -141,6 +142,12 @@ node.link_remote(sink.olink_object_name())
 
 # create and register sink for testbed1.StructArrayInterface
 sink = testbed1_olink.StructArrayInterfaceSink()
+node.link_remote(sink.olink_object_name())
+
+
+
+# create and register sink for tb.empty.EmptyInterface
+sink = tb_empty_olink.EmptyInterfaceSink()
 node.link_remote(sink.olink_object_name())
 
 

--- a/goldenmaster/olink_server.py
+++ b/goldenmaster/olink_server.py
@@ -27,6 +27,9 @@ import tb_simple_impl
 import testbed1_olink
 import testbed1_impl
 
+import tb_empty_olink
+import tb_empty_impl
+
 testbed2_olink.ManyParamInterfaceSource(testbed2_impl.ManyParamInterface())
 testbed2_olink.NestedStruct1InterfaceSource(testbed2_impl.NestedStruct1Interface())
 testbed2_olink.NestedStruct2InterfaceSource(testbed2_impl.NestedStruct2Interface())
@@ -49,6 +52,8 @@ tb_simple_olink.SimpleArrayInterfaceSource(tb_simple_impl.SimpleArrayInterface()
 
 testbed1_olink.StructInterfaceSource(testbed1_impl.StructInterface())
 testbed1_olink.StructArrayInterfaceSource(testbed1_impl.StructArrayInterface())
+
+tb_empty_olink.EmptyInterfaceSource(tb_empty_impl.EmptyInterface())
 
 
 

--- a/goldenmaster/tb_empty_api/__init__.py
+++ b/goldenmaster/tb_empty_api/__init__.py
@@ -1,0 +1,4 @@
+
+from .api import EmptyEnum as EmptyEnum
+from .api import EmptyStruct  as EmptyStruct
+from .api import IEmptyInterface  as IEmptyInterface

--- a/goldenmaster/tb_empty_api/api.py
+++ b/goldenmaster/tb_empty_api/api.py
@@ -1,0 +1,52 @@
+from pydantic import BaseModel, Field
+from enum import IntEnum
+
+
+
+class EmptyEnum(IntEnum):
+    pass
+
+class EmptyStruct(BaseModel):
+    pass
+
+class IEmptyInterface:
+    pass
+
+
+def as_int(v):
+    return int(v)
+
+def from_int(v):
+    return v
+
+def as_string(v):
+    return str(v)
+
+def from_string(v):
+    return v
+
+
+def as_bool(v):
+    return str(v).lower() in ['true', '1', 't', 'y', 'yes']
+
+def from_bool(v):
+    return v
+
+def as_float(v):
+    return float(v)
+
+def from_float(v):
+    return v
+
+def as_empty_enum(v):
+    return EmptyEnum(int(v))
+
+def from_empty_enum(v):
+    return v
+
+def as_empty_struct(v):
+    return EmptyStruct.parse_obj(v)
+
+def from_empty_struct(v):
+    return v.dict()
+

--- a/goldenmaster/tb_empty_http/client.py
+++ b/goldenmaster/tb_empty_http/client.py
@@ -1,0 +1,12 @@
+import requests
+import os
+
+from tb_empty_api import api
+from . import shared
+
+
+
+class EmptyInterface(api.IEmptyInterface):
+    def __init__(self, url='http://localhost:8000'):
+        super().__init__()
+        self._url = url

--- a/goldenmaster/tb_empty_http/routes.py
+++ b/goldenmaster/tb_empty_http/routes.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+
+
+
+from tb.empty import EmptyInterface
+
+from . import shared
+
+router = APIRouter()
+
+
+empty_interface = EmptyInterface()
+
+
+
+

--- a/goldenmaster/tb_empty_http/shared.py
+++ b/goldenmaster/tb_empty_http/shared.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from typing import Iterable
+from tb.empty_api import api
+
+class EmptyInterfaceState(BaseModel):
+    pass
+
+
+

--- a/goldenmaster/tb_empty_impl/__init__.py
+++ b/goldenmaster/tb_empty_impl/__init__.py
@@ -1,0 +1,2 @@
+
+from .empty_interface import EmptyInterface as EmptyInterface

--- a/goldenmaster/tb_empty_impl/empty_interface.py
+++ b/goldenmaster/tb_empty_impl/empty_interface.py
@@ -1,0 +1,7 @@
+from tb_empty_api import api
+from typing import Iterable
+
+class EmptyInterface(api.IEmptyInterface):
+    def __init__(self, notifier=None):
+        super().__init__()
+        self._notifier = notifier

--- a/goldenmaster/tb_empty_impl/test_empty_interface.py
+++ b/goldenmaster/tb_empty_impl/test_empty_interface.py
@@ -1,0 +1,7 @@
+
+from tb_empty_api import api
+from tb_empty_impl import EmptyInterface
+
+class TestEmptyInterface:
+    pass
+

--- a/goldenmaster/tb_empty_olink/__init__.py
+++ b/goldenmaster/tb_empty_olink/__init__.py
@@ -1,0 +1,3 @@
+
+from .sources import EmptyInterfaceSource as EmptyInterfaceSource
+from .sinks import EmptyInterfaceSink as EmptyInterfaceSink

--- a/goldenmaster/tb_empty_olink/shared.py
+++ b/goldenmaster/tb_empty_olink/shared.py
@@ -1,0 +1,16 @@
+class EventHook(object):
+    def __init__(self):
+        self.__handlers = []
+
+    def __iadd__(self, handler):
+        self.__handlers.append(handler)
+        return self
+
+    def __isub__(self, handler):
+        self.__handlers.remove(handler)
+        return self
+
+    def fire(self, *args, **keywargs):
+        for handler in self.__handlers:
+            handler(*args, **keywargs)
+

--- a/goldenmaster/tb_empty_olink/sinks.py
+++ b/goldenmaster/tb_empty_olink/sinks.py
@@ -1,0 +1,35 @@
+import asyncio
+from typing import Any
+from olink.core.types import Name
+from olink.clientnode import IObjectSink, ClientNode
+from .shared import EventHook
+from tb_empty_api import api
+class EmptyInterfaceSink(IObjectSink):
+    def __init__(self):
+        super().__init__()
+        self.on_property_changed = EventHook()
+        self.client = ClientNode.register_sink(self)
+
+    async def _invoke(self, name, args):
+        future = asyncio.get_running_loop().create_future()
+        def func(args):
+            return future.set_result(args.value)
+        self.client.invoke_remote('tb.empty.EmptyInterface/EmptyInterface', args, func)
+        return await asyncio.wait_for(future, 500)
+
+    def olink_object_name(self):
+        return 'tb.empty.EmptyInterface'
+
+    def olink_on_init(self, name: str, props: object, node: "ClientNode"):
+        for k in props:
+            setattr(self, k, props[k])
+
+    def olink_on_property_changed(self, name: str, value: Any) -> None:
+        path = Name.path_from_name(name)
+        setattr(self, path, value)
+        self.on_property_changed.fire(path, value)
+
+    def olink_on_signal(self, name: str, args: list[Any]):
+        path = Name.path_from_name(name)
+        hook = getattr(self, f'on_{path}')        
+        hook.fire(*args)

--- a/goldenmaster/tb_empty_olink/sources.py
+++ b/goldenmaster/tb_empty_olink/sources.py
@@ -1,0 +1,39 @@
+from olink.core.types import Name
+from olink.remotenode import IObjectSource, RemoteNode
+from tb_empty_api import api
+from typing import Any
+import logging
+
+class EmptyInterfaceSource(IObjectSource):
+    impl: api.IEmptyInterface
+    def __init__(self, impl: api.IEmptyInterface):
+        self.impl = impl
+        impl._notifier = self
+        RemoteNode.register_source(self)
+
+    def olink_object_name(self):
+        return "tb.empty.EmptyInterface"
+
+    def olink_set_property(self, name: str, value: Any):
+        path = Name.path_from_name(name)
+        logging.info("unknown property: %s", name)
+
+
+    def olink_invoke(self, name: str, args: list[Any]) -> Any:
+        path = Name.path_from_name(name)      
+        logging.info("unknown operation: %s", name)
+
+    def olink_linked(self, name: str, node: "RemoteNode"):
+        print('linked')
+
+    def olink_collect_properties(self) -> object:
+        props = {}
+        return props
+
+    def notify_signal(self, symbol, args):
+        path = Name.path_from_name(symbol)
+        logging.info("unknown signal %s", symbol)
+
+    def notify_property(self, symbol, value):
+        path = Name.path_from_name(symbol)
+        logging.info("unknown property %s", symbol)

--- a/templates/api/api.py.tpl
+++ b/templates/api/api.py.tpl
@@ -6,6 +6,8 @@ from enum import IntEnum
 class {{ .Name }}(IntEnum):
     {{- range .Members }}
     {{ snake .Name }} = {{ .Value }}
+    {{- else }}
+    pass
     {{- end }}
 {{- end }}
 
@@ -14,6 +16,8 @@ class {{ .Name }}(IntEnum):
 class {{ Camel .Name }}(BaseModel):
     {{- range .Fields }}
     {{ snake .Name }}: {{ pyReturn "" . }} = Field(None, alias="{{.Name}}")
+    {{- else }}
+    pass
     {{- end }}
 {{- end }}
 
@@ -33,6 +37,9 @@ class I{{ $class}}:
 
     def {{snake .Name}}({{pyParams "" .Params}}):
         raise NotImplementedError
+    {{- end }}
+    {{- if .NoMembers }}
+    pass
     {{- end }}
 {{- end }}
 


### PR DESCRIPTION
there is currently no empty enums, structs or interfaces in our test api. We need to add this.

This will fix python for these cases.