### PR TITLE
fix(mqtt): reject NaN/Inf in JSON payloads

### DIFF
--- a/goldenmaster/apigear/mqtt/base.py
+++ b/goldenmaster/apigear/mqtt/base.py
@@ -109,9 +109,9 @@ class BaseClient:
     
     def get_client_id(self):
         return self.client._client_id
-    
+
     def to_payload(self, arguments) -> str:
-        return bytes(json.dumps(arguments), 'utf-8')
-    
+        return bytes(json.dumps(arguments, allow_nan=False), 'utf-8')
+
     def from_payload(self, payload: str) -> list[Any]:
         return json.loads(payload.decode('utf-8'))

--- a/templates/apigear/mqtt/base.py
+++ b/templates/apigear/mqtt/base.py
@@ -109,9 +109,9 @@ class BaseClient:
     
     def get_client_id(self):
         return self.client._client_id
-    
+
     def to_payload(self, arguments) -> str:
-        return bytes(json.dumps(arguments), 'utf-8')
-    
+        return bytes(json.dumps(arguments, allow_nan=False), 'utf-8')
+
     def from_payload(self, payload: str) -> list[Any]:
         return json.loads(payload.decode('utf-8'))


### PR DESCRIPTION
## Summary
Pass `allow_nan=False` to `json.dumps` in `BaseClient.to_payload` so NaN/Infinity values raise `ValueError` instead of producing non-standard JSON literals (`NaN`, `Infinity`) that downstream parsers reject.

Mirrors the hardening already applied to olink-core v0.4.0's `MessageConverter.to_string`.

## Test plan
- [x] Existing MQTT tests pass