### PR TITLE
Release/v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ commit messages follow [Conventional Commits](https://conventionalcommits.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- MQTT: generated `__on_<op>_resp` sink handlers no longer raise
+  `KeyError` on duplicate deliveries (QoS-2 retransmits, pytest
+  teardown). The pending-call lookup now uses `pop(callId, None)`.
+
 ## [2.0.0] - 2026-04-30
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ commit messages follow [Conventional Commits](https://conventionalcommits.org).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-07
+
 ### Fixed
 
 - MQTT: generated `__on_<op>_resp` sink handlers no longer raise

--- a/goldenmaster/counter/mqtt/sinks.py
+++ b/goldenmaster/counter/mqtt/sinks.py
@@ -190,22 +190,30 @@ class CounterClientAdapter():
         return
 
     def __on_increment_resp(self, value, callId):
-       callback = self.pending_calls.increment.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.increment.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_increment_array_resp(self, value, callId):
-       callback = self.pending_calls.increment_array.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.increment_array.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_decrement_resp(self, value, callId):
-       callback = self.pending_calls.decrement.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.decrement.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_decrement_array_resp(self, value, callId):
-       callback = self.pending_calls.decrement_array.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.decrement_array.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/goldenmaster/tb_enum/mqtt/sinks.py
+++ b/goldenmaster/tb_enum/mqtt/sinks.py
@@ -208,22 +208,30 @@ class EnumInterfaceClientAdapter():
         return
 
     def __on_func0_resp(self, value, callId):
-       callback = self.pending_calls.func0.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func0.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func3_resp(self, value, callId):
-       callback = self.pending_calls.func3.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func3.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/goldenmaster/tb_names/mqtt/sinks.py
+++ b/goldenmaster/tb_names/mqtt/sinks.py
@@ -164,12 +164,16 @@ class NamEsClientAdapter():
         return
 
     def __on_some_function_resp(self, value, callId):
-       callback = self.pending_calls.some_function.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.some_function.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_some_function2_resp(self, value, callId):
-       callback = self.pending_calls.some_function2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.some_function2.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/goldenmaster/tb_same1/mqtt/sinks.py
+++ b/goldenmaster/tb_same1/mqtt/sinks.py
@@ -82,7 +82,9 @@ class SameStruct1InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -212,12 +214,16 @@ class SameStruct2InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -306,7 +312,9 @@ class SameEnum1InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -436,12 +444,16 @@ class SameEnum2InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/goldenmaster/tb_same2/mqtt/sinks.py
+++ b/goldenmaster/tb_same2/mqtt/sinks.py
@@ -82,7 +82,9 @@ class SameStruct1InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -212,12 +214,16 @@ class SameStruct2InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -306,7 +312,9 @@ class SameEnum1InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -436,12 +444,16 @@ class SameEnum2InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/goldenmaster/tb_simple/mqtt/sinks.py
+++ b/goldenmaster/tb_simple/mqtt/sinks.py
@@ -60,7 +60,9 @@ class VoidInterfaceClientAdapter():
         return
 
     def __on_func_void_resp(self, value, callId):
-       callback = self.pending_calls.func_void.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_void.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -467,52 +469,72 @@ class SimpleInterfaceClientAdapter():
         return
 
     def __on_func_no_return_value_resp(self, value, callId):
-       callback = self.pending_calls.func_no_return_value.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_no_return_value.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_no_params_resp(self, value, callId):
-       callback = self.pending_calls.func_no_params.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_no_params.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_bool_resp(self, value, callId):
-       callback = self.pending_calls.func_bool.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_bool.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int_resp(self, value, callId):
-       callback = self.pending_calls.func_int.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int32_resp(self, value, callId):
-       callback = self.pending_calls.func_int32.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int32.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int64_resp(self, value, callId):
-       callback = self.pending_calls.func_int64.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int64.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float_resp(self, value, callId):
-       callback = self.pending_calls.func_float.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float32_resp(self, value, callId):
-       callback = self.pending_calls.func_float32.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float32.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float64_resp(self, value, callId):
-       callback = self.pending_calls.func_float64.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float64.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_string_resp(self, value, callId):
-       callback = self.pending_calls.func_string.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_string.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -933,42 +955,58 @@ class SimpleArrayInterfaceClientAdapter():
         return
 
     def __on_func_bool_resp(self, value, callId):
-       callback = self.pending_calls.func_bool.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_bool.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int_resp(self, value, callId):
-       callback = self.pending_calls.func_int.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int32_resp(self, value, callId):
-       callback = self.pending_calls.func_int32.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int32.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int64_resp(self, value, callId):
-       callback = self.pending_calls.func_int64.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int64.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float_resp(self, value, callId):
-       callback = self.pending_calls.func_float.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float32_resp(self, value, callId):
-       callback = self.pending_calls.func_float32.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float32.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float64_resp(self, value, callId):
-       callback = self.pending_calls.func_float64.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float64.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_string_resp(self, value, callId):
-       callback = self.pending_calls.func_string.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_string.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -1075,12 +1113,16 @@ class NoPropertiesInterfaceClientAdapter():
         return
 
     def __on_func_void_resp(self, value, callId):
-       callback = self.pending_calls.func_void.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_void.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_bool_resp(self, value, callId):
-       callback = self.pending_calls.func_bool.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_bool.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -1278,12 +1320,16 @@ class NoSignalsInterfaceClientAdapter():
         self.on_prop_int_changed.fire(self._prop_int)
 
     def __on_func_void_resp(self, value, callId):
-       callback = self.pending_calls.func_void.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_void.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_bool_resp(self, value, callId):
-       callback = self.pending_calls.func_bool.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_bool.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/goldenmaster/testbed1/mqtt/sinks.py
+++ b/goldenmaster/testbed1/mqtt/sinks.py
@@ -208,22 +208,30 @@ class StructInterfaceClientAdapter():
         return
 
     def __on_func_bool_resp(self, value, callId):
-       callback = self.pending_calls.func_bool.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_bool.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int_resp(self, value, callId):
-       callback = self.pending_calls.func_int.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float_resp(self, value, callId):
-       callback = self.pending_calls.func_float.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_string_resp(self, value, callId):
-       callback = self.pending_calls.func_string.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_string.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -486,27 +494,37 @@ class StructArrayInterfaceClientAdapter():
         return
 
     def __on_func_bool_resp(self, value, callId):
-       callback = self.pending_calls.func_bool.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_bool.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int_resp(self, value, callId):
-       callback = self.pending_calls.func_int.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float_resp(self, value, callId):
-       callback = self.pending_calls.func_float.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_string_resp(self, value, callId):
-       callback = self.pending_calls.func_string.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_string.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_enum_resp(self, value, callId):
-       callback = self.pending_calls.func_enum.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_enum.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -764,27 +782,37 @@ class StructArray2InterfaceClientAdapter():
         return
 
     def __on_func_bool_resp(self, value, callId):
-       callback = self.pending_calls.func_bool.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_bool.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_int_resp(self, value, callId):
-       callback = self.pending_calls.func_int.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_int.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_float_resp(self, value, callId):
-       callback = self.pending_calls.func_float.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_float.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_string_resp(self, value, callId):
-       callback = self.pending_calls.func_string.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_string.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_enum_resp(self, value, callId):
-       callback = self.pending_calls.func_enum.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_enum.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/goldenmaster/testbed2/mqtt/sinks.py
+++ b/goldenmaster/testbed2/mqtt/sinks.py
@@ -220,22 +220,30 @@ class ManyParamInterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func3_resp(self, value, callId):
-       callback = self.pending_calls.func3.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func3.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func4_resp(self, value, callId):
-       callback = self.pending_calls.func4.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func4.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -357,17 +365,23 @@ class NestedStruct1InterfaceClientAdapter():
         return
 
     def __on_func_no_return_value_resp(self, value, callId):
-       callback = self.pending_calls.func_no_return_value.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_no_return_value.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func_no_params_resp(self, value, callId):
-       callback = self.pending_calls.func_no_params.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func_no_params.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -503,12 +517,16 @@ class NestedStruct2InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:
@@ -687,17 +705,23 @@ class NestedStruct3InterfaceClientAdapter():
         return
 
     def __on_func1_resp(self, value, callId):
-       callback = self.pending_calls.func1.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func1.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func2_resp(self, value, callId):
-       callback = self.pending_calls.func2.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func2.pop(callId, None)
        if callback != None:
            callback(value)
 
     def __on_func3_resp(self, value, callId):
-       callback = self.pending_calls.func3.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.func3.pop(callId, None)
        if callback != None:
            callback(value)
     class MethodTopics:

--- a/templates/mqtt/sinks.py.tpl
+++ b/templates/mqtt/sinks.py.tpl
@@ -186,7 +186,9 @@ class {{Camel .Name}}ClientAdapter():
     {{- range .Operations }}
 
     def __on_{{snake .Name}}_resp(self, value, callId):
-       callback = self.pending_calls.{{snake .Name}}.pop(callId)
+       # Tolerate duplicate deliveries: paho-mqtt may re-invoke this handler for
+       # the same (topic, callId) on QoS-2 retransmits or during teardown.
+       callback = self.pending_calls.{{snake .Name}}.pop(callId, None)
        if callback != None:
            callback(value)
     {{- end }}


### PR DESCRIPTION
## 📑 Description

- fix(mqtt) Generated __on_<op>_resp sink handlers no longer raise KeyError on duplicate deliveries (QoS-2 retransmits, pytest teardown).  The  pending-call lookup uses pop(callId, None); the existing None-guard handles the missing-key case. 
- release v2.0.1

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->