### PR TITLE
chore: update LICENSE copyright and add README License section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022 ApiGear
+Copyright (c) 2022 ApiGear UG (haftungsbeschränkt)
+Copyright (c) 2022-2026 Epic Games, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ uvicorn olink_server:app
 
 The implementation is in the module `{$module_name}_impl` folder. Each file contains one class that implements the service interface. All methods raise a not implemented exception. It is up to you to implement the service according to your needs.
 
+
+## License
+
+Licensed under the [MIT License](./LICENSE). See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
Updates the LICENSE to the standard, entity-accurate copyright attribution (drops the contradictory "All rights reserved." trailer and corrects the year range) and adds a README License section where missing. MIT is the standard license used across ApiGear projects.